### PR TITLE
Updated Graphs of All Ads Summary Data & Filtering

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ flask~=2.2
 gunicorn~=20.1
 numpy~=1.24
 pandas~=1.5
+pyarrow~=12.0
 plotly~=5.13
 dash-iconify~=0.1
 statsmodels~=0.13

--- a/src/app.py
+++ b/src/app.py
@@ -131,6 +131,7 @@ app.layout = html.Div(
         dcc.Store(id="price-summary-store", storage_type="session"),
         dcc.Store(id="num-ads-summary-store", storage_type="session"),
         dcc.Store(id="mileage-summary-store", storage_type="session"),
+        dcc.Store(id="makes-models-store", storage_type="session"),
         html.Div(
             className="div-app",
             id="div-app",
@@ -176,6 +177,7 @@ app.index_string = """<!DOCTYPE html>
 </html>
 """
 
+
 # add callback for toggling the collapse on small screens
 @app.callback(
     Output("navbar-collapse", "is_open"),
@@ -193,6 +195,7 @@ def toggle_navbar_collapse(n, is_open):
     Output("price-summary-store", "data"),
     Output("num-ads-summary-store", "data"),
     Output("mileage-summary-store", "data"),
+    Output("makes-models-store", "data"),
     Input("first-load", "children"),
     [
         State("price-summary-store", "data"),
@@ -201,10 +204,8 @@ def toggle_navbar_collapse(n, is_open):
     ],
 )
 def load_data(first_load, price_summary, num_ads_summary, mileage_summary):
-
     # if any summary is None, then we need to load data
     if not price_summary or not num_ads_summary or not mileage_summary:
-
         start_time = time.time()
         azure_blob = AzureBlob()
         ad_price_summary = azure_blob.load_parquet(
@@ -216,10 +217,13 @@ def load_data(first_load, price_summary, num_ads_summary, mileage_summary):
         num_ads_summary = azure_blob.load_parquet(
             "processed/num_ads_summary.parquet"
         ).to_dict()
-        logger.info(
+        makes_models = azure_blob.load_parquet(
+            "processed/makes_models.parquet"
+        ).to_dict()
+        logger.debug(
             f"Loaded data from Azure Blob Storage in {time.time() - start_time} seconds"
         )
-        return ad_price_summary, num_ads_summary, mileage_summary
+        return ad_price_summary, num_ads_summary, mileage_summary, makes_models
     else:
         logger.debug("Data already loaded, skipping")
         raise dash.exceptions.PreventUpdate

--- a/src/pages/explore_ads.py
+++ b/src/pages/explore_ads.py
@@ -16,9 +16,7 @@ from dash import Dash, dcc, html, Input, Output, State, callback
 import dash_bootstrap_components as dbc
 import dash_mantine_components as dmc
 from dash_iconify import DashIconify
-import plotly.express as px
-import numpy as np
-import time
+import pandas as pd
 
 cur_dir = os.getcwd()
 try:
@@ -32,13 +30,18 @@ if SRC_PATH not in sys.path:
 
 from src.data.load_preprocess_craigslist import load_craigslist_data
 from src.visualizations.explore_ads_plots import (
-    plot_vehicle_price_over_time,
-    plot_vehicle_condition,
-    plot_odometer_histogram,
+    plot_vehicle_prices_summary,
+    plot_mileage_distribution_summary,
+    plot_num_ads_summary,
 )
+from src.visualizations.utils import blank_placeholder_plot
 from src.pages.dash_styles import SIDEBAR_STYLE, CONTENT_STYLE
+from src.logs import get_logger
 
-vehicles_df = load_craigslist_data()
+INVALID_MODELS = ["other"]
+
+# Create a custom logger
+logger = get_logger(__name__)
 
 filtering_accordion = html.Div(
     dbc.Accordion(

--- a/src/pages/explore_ads.py
+++ b/src/pages/explore_ads.py
@@ -44,38 +44,37 @@ filtering_accordion = html.Div(
     dbc.Accordion(
         [
             dbc.AccordionItem(
-                dmc.MultiSelect(
-                    label="Select Manufacturers",
-                    placeholder="All Manufacturers",
-                    id="explore-manufacturer-select",
-                    searchable=True,
-                    clearable=True,
-                    nothingFound="No matching manufacturers found",
-                    value=["Toyota", "Honda"],
-                    data=vehicles_df.manufacturer.unique(),
-                ),
-                title="Manufacturer",
-            ),
-            dbc.AccordionItem(
-                dmc.MultiSelect(
-                    label="Select Models",
-                    placeholder="All Models",
-                    id="explore-model-select",
-                    searchable=True,
-                    clearable=True,
-                    nothingFound="No matching models found",
-                    value=[],
-                    data=vehicles_df.model.unique(),
-                ),
-                title="Model",
+                children=[
+                    dmc.MultiSelect(
+                        label="Select Vehicle Makes",
+                        placeholder="All Makes",
+                        id="explore-make-select",
+                        searchable=True,
+                        clearable=True,
+                        nothingFound="No matching makes found",
+                        value=[],
+                    ),
+                    dmc.MultiSelect(
+                        label="Select Models",
+                        placeholder="No models selected",
+                        id="explore-model-select",
+                        searchable=True,
+                        clearable=True,
+                        nothingFound="No matching models found",
+                        value=["civic", "tundra", "cr-v"],
+                        maxSelectedValues=6,
+                        required=True,
+                    ),
+                ],
+                title="Make & Model",
             ),
             dbc.AccordionItem(
                 dcc.RangeSlider(
-                    min=vehicles_df.price.min(),
-                    max=vehicles_df.price.max(),
-                    step=1,
+                    min=0,
+                    max=100_000,
+                    step=100,
                     id="explore-price-slider",
-                    value=[0, vehicles_df.price.max()],
+                    value=[0, 100_000],
                     tooltip={"placement": "bottom", "always_visible": True},
                     marks=None,
                 ),
@@ -83,19 +82,18 @@ filtering_accordion = html.Div(
             ),
             dbc.AccordionItem(
                 dcc.RangeSlider(
-                    min=vehicles_df.year.min(),
-                    max=vehicles_df.year.max(),
+                    min=0,
+                    max=15,
                     step=1,
-                    id="explore-year-slider",
-                    value=[vehicles_df.year.min(), vehicles_df.year.max()],
+                    id="explore-age-slider",
+                    value=[0, 15],
                     tooltip={"placement": "bottom", "always_visible": True},
                     marks=None,
                 ),
-                title="Year",
+                title="Vehicle Age",
             ),
         ],
         flush=True,
-        start_collapsed=True,
         always_open=True,
     ),
 )
@@ -141,13 +139,13 @@ sidebar = html.Div(
 vehicle_condition_card = (
     dbc.Card(
         [
-            dbc.CardHeader("Vehicle Condition"),
+            dbc.CardHeader("Number of Ads Analyzed"),
             dbc.CardBody(
                 [
                     dbc.Spinner(
                         dcc.Graph(
-                            id="vehicle-condition-plot",
-                            figure=None,
+                            id="num-ads-summary-plot",
+                            figure=blank_placeholder_plot(height=300),
                         ),
                         type="grow",
                         color="primary",
@@ -165,15 +163,14 @@ content = dbc.Container(
             dbc.Col(
                 dbc.Card(
                     [
-                        dbc.CardHeader("Car Prices Over Time"),
+                        dbc.CardHeader("Car Prices by Age"),
                         dbc.CardBody(
                             [
                                 dbc.Spinner(
                                     dcc.Graph(
-                                        id="price-over-time-plot",
-                                        figure=plot_vehicle_price_over_time(
-                                            vehicles_df
-                                        ),
+                                        id="price-age-summary-plot",
+                                        figure=blank_placeholder_plot(height=300),
+                                        config={"displayModeBar": False},
                                     ),
                                     type="grow",
                                     color="primary",
@@ -204,13 +201,13 @@ content = dbc.Container(
                 dbc.Col(
                     dbc.Card(
                         [
-                            dbc.CardHeader("Vehicle Condition"),
+                            dbc.CardHeader("Number of Ads Analyzed"),
                             dbc.CardBody(
                                 [
                                     dbc.Spinner(
                                         dcc.Graph(
-                                            id="vehicle-condition-plot",
-                                            figure=plot_vehicle_condition(vehicles_df),
+                                            id="num-ads-summary-plot",
+                                            figure=blank_placeholder_plot(height=300),
                                         ),
                                         type="grow",
                                         color="primary",
@@ -226,13 +223,13 @@ content = dbc.Container(
                 dbc.Col(
                     dbc.Card(
                         [
-                            dbc.CardHeader("Vehicle Mileage"),
+                            dbc.CardHeader("Average Yearly Mileage"),
                             dbc.CardBody(
                                 [
                                     dbc.Spinner(
                                         dcc.Graph(
-                                            id="vehicle-odometer-plot",
-                                            figure=plot_odometer_histogram(vehicles_df),
+                                            id="vehicle-mileage-plot",
+                                            figure=blank_placeholder_plot(height=300),
                                         ),
                                         type="grow",
                                         color="primary",
@@ -255,6 +252,7 @@ content = dbc.Container(
 
 layout = html.Div(
     [
+        html.Div(id="explore-first-load", children=True, style={"display": "none"}),
         dbc.Row(
             [
                 dbc.Col(sidebar, width=12, lg=3, className="g-0"),

--- a/src/pages/home.py
+++ b/src/pages/home.py
@@ -44,7 +44,7 @@ explore_ads_card = dbc.Card(
                 dmc.Divider(variant="solid"),
                 dmc.Anchor(
                     dmc.Button(
-                        "Explore Past Ads",
+                        "Explore 3+ Million Ads",
                         variant="gradient",
                         gradient={"from": "indigo", "to": "cyan"},
                         leftIcon=[

--- a/src/visualizations/explore_ads_plots.py
+++ b/src/visualizations/explore_ads_plots.py
@@ -165,26 +165,40 @@ def plot_mileage_distribution_summary(mileage_summary_df):
     return fig
 
 
-def plot_odometer_histogram(vehicles):
-    fig = px.histogram(
-        vehicles,
-        x="odometer_km",
-        color="manufacturer",
+# plot a horizontal bar chart with model on the left and number of ads on x-axis
+def plot_num_ads_summary(num_ads_summary_df):
+    """Plots the number of ads for selected vehicles.
+
+    Parameters
+    ----------
+    num_ads_summary_df : pd.DataFrame
+        DataFrame with columns `model` and `num_ads`.
+
+    Returns
+    -------
+    plotly.graph_objects.Figure
+        Plotly figure object.
+    """
+    fig = px.bar(
+        num_ads_summary_df,
+        x="num_ads",
+        y="model",
+        color="model",
+        orientation="h",
         labels={
-            "odometer_km": "Odometer (km)",
-            "manufacturer": "Manufacturer",
+            "num_ads": "Number of Ads",
+            "model": "Vehicle Model",
         },
-        hover_name="model",
-        hover_data=["year", "condition", "cylinders", "fuel", "transmission"],
-        template="plotly_white",
+        # have text_auto show 1000"s of ads with one decmila  place
+        text_auto=".2%s",
         height=300,
     )
 
     fig.update_layout(
-        xaxis_range=[0, min(vehicles.odometer_km.max(), 600000)],
-        legend=dict(yanchor="top", y=0.99, xanchor="right", x=0.99),
-        yaxis_title="No. of Vehicles",
         margin=dict(l=5, r=5, t=5, b=5),
+        legend=dict(yanchor="top", y=0.99, xanchor="right", x=0.99),
+        showlegend=False,
+        yaxis={"categoryorder": "total ascending"},
     )
 
     return fig

--- a/src/visualizations/explore_ads_plots.py
+++ b/src/visualizations/explore_ads_plots.py
@@ -29,39 +29,46 @@ def hex_to_rgba(hex: str, opacity: float = 1.0):
         + str(int(hex[2 * hlen // 3 :], 16))
         + f",{opacity:.2f})"
     )
+
+
+def plot_vehicle_prices_summary(price_summary_df):
+    """Plots the price of selected vehicles by their age at posting.
+
+    Parameters
+    ----------
+    price_summary_df : pd.DataFrame
+        DataFrame with columns `age` and remaining columns as vehicle model names.
+
+    Returns
+    -------
+    plotly.graph_objects.Figure
+        Plotly figure object.
+    """
     fig = px.scatter(
-        vehicles_df,
-        x="year",
+        price_summary_df,
+        x="age",
         y="price",
-        color="manufacturer",
-        opacity=0.5,
+        color="model",
         trendline="lowess",
-        # title="Price of used vehicles over time",
         labels={
-            "year": "Year",
-            "price": "Price",
-            "manufacturer": "Manufacturer",
+            "age": "Age of Vehicle (years)",
+            "price": "Avg. Price ($CAD)",
+            "model": "Vehicle Model",
         },
-        hover_name="model",
-        hover_data=["odometer_km", "condition", "cylinders", "fuel", "transmission"],
-        template="plotly_white",
-        # width=800,
         height=300,
+    ).update_xaxes(
+        range=[price_summary_df["age"].min() - 0.1, price_summary_df["age"].max() + 0.1]
     )
 
     fig.update_layout(
         xaxis=dict(
             tickmode="linear",
-            tick0=1990,
-            dtick=5,
-        ),
-        yaxis=dict(
-            tickmode="linear",
             tick0=0,
-            dtick=10000,
+            dtick=1,
         ),
         margin=dict(l=5, r=5, t=5, b=5),
-        legend=dict(yanchor="top", y=0.99, xanchor="left", x=0.01),
+        legend=dict(yanchor="top", y=0.99, xanchor="right", x=0.99),
+        hovermode="x unified",
     )
 
     return fig

--- a/src/visualizations/explore_ads_plots.py
+++ b/src/visualizations/explore_ads_plots.py
@@ -5,8 +5,30 @@ import pandas as pd
 import plotly.express as px
 
 
-def plot_vehicle_price_over_time(vehicles_df):
+def hex_to_rgba(hex: str, opacity: float = 1.0):
+    """Converts a hex color code to an rgba color code.
 
+    Parameters
+    ----------
+    hex : str
+        Hex color code.
+
+    Returns
+    -------
+    str
+        RGBA color code.
+    """
+    hex = hex.lstrip("#")
+    hlen = len(hex)
+    return (
+        "rgba("
+        + str(int(hex[: hlen // 3], 16))
+        + ","
+        + str(int(hex[hlen // 3 : 2 * hlen // 3], 16))
+        + ","
+        + str(int(hex[2 * hlen // 3 :], 16))
+        + f",{opacity:.2f})"
+    )
     fig = px.scatter(
         vehicles_df,
         x="year",

--- a/src/visualizations/explore_ads_plots.py
+++ b/src/visualizations/explore_ads_plots.py
@@ -3,6 +3,7 @@
 
 import pandas as pd
 import plotly.express as px
+import plotly.graph_objects as go
 
 
 def hex_to_rgba(hex: str, opacity: float = 1.0):

--- a/src/visualizations/utils.py
+++ b/src/visualizations/utils.py
@@ -1,0 +1,28 @@
+# Author: Ty Andrews
+# Date: 2023-05-06
+
+import plotly.express as px
+
+
+def blank_placeholder_plot(background_color="white", height=None, width=None):
+    """Creates an empty plot to be used on page load before callbacks complete,
+    allows page load and all figure updates/data loading to be managed in callbacks
+    without empty plots being shown.
+
+    Args:
+        background_color (str, optional): What color the background should match to be "invisible" until updated.
+                                         Defaults to "white".
+
+    Returns:
+        px.Scatter : Empty plot with lines removed and formatting updated to be blank.
+    """
+
+    blank_plot = px.scatter(x=[0, 1], y=[0, 1], height=height, width=width)
+    blank_plot.update_xaxes(showgrid=False, showticklabels=False, visible=False)
+    blank_plot.update_yaxes(showgrid=False, showticklabels=False, visible=False)
+
+    blank_plot.update_traces(marker=dict(color=background_color))
+
+    blank_plot.layout.plot_bgcolor = background_color
+    blank_plot.layout.paper_bgcolor = background_color
+    return blank_plot


### PR DESCRIPTION
This PR connects the summarized data loaded from Blob storage and filters/plots the data in the explore ads page.

Other improvements included here:
- added the makes-models data store to be accessible in the app
- added blank placeholder plots for a smoother loading experience
- formatted the drop downs to include the number of ads etc.

closes #3 