### PR TITLE
Bug: Dash Mantine Components Version Issue

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 dash==2.8.1
 dash-bootstrap-components==1.4.0
-dash-mantine-components==0.10.2
+dash-mantine-components==0.12.1
 dash-core-components==2.0.0
 flask~=2.2
 gunicorn~=20.1


### PR DESCRIPTION
Error during deployment:
The dash_mantine_components.NumberInput component (version 0.10.2) with the ID "vehicle-price-input" received an unexpected keyword argument: persistence_type